### PR TITLE
Fixed issues when dealing with java Boolean (Object type), and Kotlin Boolean props.

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/ResolverDataFetcher.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/ResolverDataFetcher.kt
@@ -7,9 +7,9 @@ import graphql.schema.DataFetchingEnvironment
 import java.lang.reflect.Method
 
 class ResolverDataFetcher(
-  val resolver: GraphQLResolver?,
-  val method: Method,
-  val passEnvironment: Boolean) : DataFetcher {
+    val resolver: GraphQLResolver?,
+    val method: Method,
+    val passEnvironment: Boolean) : DataFetcher {
 
     companion object {
         val mapper = ObjectMapper().registerKotlinModule()

--- a/src/main/kotlin/com/coxautodev/graphql/tools/ResolverDataFetcher.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/ResolverDataFetcher.kt
@@ -7,9 +7,9 @@ import graphql.schema.DataFetchingEnvironment
 import java.lang.reflect.Method
 
 class ResolverDataFetcher(
-    val resolver: GraphQLResolver?,
-    val method: Method,
-    val passEnvironment: Boolean) : DataFetcher {
+  val resolver: GraphQLResolver?,
+  val method: Method,
+  val passEnvironment: Boolean) : DataFetcher {
 
     companion object {
         val mapper = ObjectMapper().registerKotlinModule()
@@ -26,9 +26,14 @@ class ResolverDataFetcher(
             return ResolverDataFetcher(resolver, method, shouldPassEnvironment(if (shouldPassSource(resolver)) arguments + 1 else arguments, method))
         }
 
+        private fun isBoolean(method: Method):Boolean =
+            method.returnType.isAssignableFrom(Boolean::class.java) ||
+            method.returnType.isPrimitive && method.returnType.javaClass.name == "boolean"
+
         private fun getMethod(clazz: Class<*>, name: String): Method? =
-            clazz.methods.find { it.name == name } ?: clazz.methods.find {
-                it.name == (if (it.returnType.isAssignableFrom(Boolean::class.java)) "is" else "get") + name.capitalize()
+            clazz.methods.find { it.name == name ||
+              (isBoolean(it) && it.name == "is${name.capitalize()}") ||
+              it.name == "get${name.capitalize()}"
             }
 
         private fun shouldPassSource(resolver: GraphQLResolver?) = resolver != null && resolver.graphQLResolverDataType() != null

--- a/src/test/groovy/com/coxautodev/graphql/tools/ResolverDataFetcherSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/ResolverDataFetcherSpec.groovy
@@ -59,12 +59,23 @@ class ResolverDataFetcherSpec extends Specification {
             resolver.get(createEnvironment(new DataClass())) == name
     }
 
-    def "data fetcher uses 'is' prefix for booleans"() {
+    def "data fetcher uses 'is' prefix for booleans (primitive type)"() {
         setup:
-            def resolver = createResolver("active", new GraphQLResolver(DataClass) {
-                boolean isActive(DataClass dataClass) { true }
-                boolean getActive(DataClass dataClass) { false }
-            })
+        def resolver = createResolver("active", new GraphQLResolver(DataClass) {
+            boolean isActive(DataClass dataClass) { true }
+            boolean getActive(DataClass dataClass) { true }
+        })
+
+        expect:
+            resolver.get(createEnvironment(new DataClass()))
+    }
+
+    def "data fetcher uses 'is' prefix for Booleans (Object type)"() {
+        setup:
+        def resolver = createResolver("active", new GraphQLResolver(DataClass) {
+            Boolean isActive(DataClass dataClass) { Boolean.TRUE }
+            Boolean getActive(DataClass dataClass) { Boolean.TRUE }
+        })
 
         expect:
             resolver.get(createEnvironment(new DataClass()))


### PR DESCRIPTION
Here are the fixes.

Fixed a failure when attempting to find the appropriate resolver for properties on data classes that have a return type of java.lang.Boolean. The java.lang.Boolean is not assignable to kotlin.Boolean::class.java. Kotlin's java platform types map to the primitive types, i.e. 'boolean'. In this case, we now check for 'boolean' as the class name. If there is a better way to do this, I'm not immediately aware. Added a test case to cover the Boolean case.
    
Another failure occurred when assuming a Boolean|boolean value on a class used the 'is' prefix. This is a Java convention and is not enforced. Kotlin does not generate 'is' properties when declaring Boolean properties as it generates a 'get' prefix on vals/vars. Kotlin Boolean values would therefore fail the method lookup. Now first trying an 'is' then, if a boolean, trying the 'is' prefix as a last resort.