### PR TITLE
Added the 'scalars()' function to the SchemaParser.Builder to allow f…

### DIFF
--- a/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
@@ -16,6 +16,7 @@ class EndToEndSpec extends Specification {
         gql = new GraphQL(SchemaParser.newParser()
             .schemaString(EndToEndSpecKt.schemaDefinition)
             .resolvers(new Query(), new Mutation(), new ItemResolver())
+            .scalars(EndToEndSpecKt.CustomUUIDScalar)
             .enums(Type)
             .dataClasses(Tag, OtherItem)
             .build()
@@ -96,5 +97,21 @@ class EndToEndSpec extends Specification {
 
         then:
             data.allItems
+    }
+
+    def "generated schema should handle scalar types"() {
+        when:
+        def data = Utils.assertNoGraphQlErrors(gql) {
+            '''
+                {
+                    itemByUUID(uuid: "38f685f1-b460-4a54-a17f-7fd69e8cf3f8") {
+                        uuid
+                    }
+                }
+                '''
+        }
+
+        then:
+        data.itemByUUID
     }
 }

--- a/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
+++ b/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
@@ -1,10 +1,19 @@
 package com.coxautodev.graphql.tools
 
+import graphql.language.StringValue
+import graphql.schema.Coercing
+import graphql.schema.GraphQLScalarType
+import java.util.UUID
+
 val schemaDefinition = """
+
+scalar UUID
+
 type Query {
     items(itemsInput: ItemSearchInput!): [Item!] @doc(d: "Get items by name")
     allItems: [AllItems!]
     itemsByInterface: [ItemInterface!]
+    itemByUUID(uuid: UUID!): Item
 }
 
 type Mutation {
@@ -29,6 +38,7 @@ type Item implements ItemInterface {
     id: Int!
     name: String!
     type: Type!
+    uuid: UUID!
     tags(names: [String!]): [Tag!]
 }
 
@@ -36,11 +46,13 @@ type OtherItem implements ItemInterface {
     id: Int!
     name: String!
     type: Type!
+    uuid: UUID!
 }
 
 interface ItemInterface {
     name: String!
     type: Type!
+    uuid: UUID!
 }
 
 union AllItems = Item | OtherItem
@@ -51,25 +63,27 @@ type Tag {
 }
 """
 
+
 val items = mutableListOf(
-    Item(0, "item1", Type.TYPE_1, listOf(Tag(1, "item1-tag1"), Tag(2, "item1-tag2"))),
-    Item(1, "item2", Type.TYPE_2, listOf(Tag(3, "item2-tag1"), Tag(4, "item2-tag2")))
+    Item(0, "item1", Type.TYPE_1, UUID.fromString("38f685f1-b460-4a54-a17f-7fd69e8cf3f8"), listOf(Tag(1, "item1-tag1"), Tag(2, "item1-tag2"))),
+    Item(1, "item2", Type.TYPE_2, UUID.fromString("38f685f1-b460-4a54-b17f-7fd69e8cf3f8"), listOf(Tag(3, "item2-tag1"), Tag(4, "item2-tag2")))
 )
 
 val otherItems = mutableListOf(
-    OtherItem(0, "otherItem1", Type.TYPE_1),
-    OtherItem(1, "otherItem2", Type.TYPE_2)
+    OtherItem(0, "otherItem1", Type.TYPE_1, UUID.fromString("38f685f1-b460-4a54-c17f-7fd69e8cf3f8")),
+    OtherItem(1, "otherItem2", Type.TYPE_2, UUID.fromString("38f685f1-b460-4a54-d17f-7fd69e8cf3f8"))
 )
 
 class Query : GraphQLRootResolver() {
     fun items(input: ItemSearchInput): List<Item> = items.filter { it.name == input.name }
     fun allItems(): List<Any> = items + otherItems
     fun itemsByInterface(): List<ItemInterface> = items + otherItems
+    fun itemByUUID(uuid: UUID): Item? = items.find { it.uuid == uuid }
 }
 
 class Mutation: GraphQLRootResolver() {
     fun addItem(input: NewItemInput): Item {
-        return Item(items.size, input.name, input.type, listOf()).apply {
+        return Item(items.size, input.name, input.type, UUID.randomUUID(), listOf()).apply {
             items.add(this)
         }
     }
@@ -82,12 +96,28 @@ class ItemResolver : GraphQLResolver(Item::class.java) {
 interface ItemInterface {
     val name: String
     val type: Type
+    val uuid: UUID
 }
 
 enum class Type { TYPE_1, TYPE_2 }
-data class Item(val id: Int, override val name: String, override val type: Type, val tags: List<Tag>) : ItemInterface
-data class OtherItem(val id: Int, override val name: String, override val type: Type) : ItemInterface
+data class Item(val id: Int, override val name: String, override val type: Type, override val uuid:UUID, val tags: List<Tag>) : ItemInterface
+data class OtherItem(val id: Int, override val name: String, override val type: Type, override val uuid:UUID) : ItemInterface
 data class Tag(val id: Int, val name: String)
 data class ItemSearchInput(val name: String)
 data class NewItemInput(val name: String, val type: Type)
 
+val CustomUUIDScalar = GraphQLScalarType("UUID", "UUID", object : Coercing {
+
+    override fun parseValue(input: Any?): Any? = serialize(input)
+
+    override fun parseLiteral(input: Any?): Any? = when (input) {
+        is StringValue -> UUID.fromString(input.value)
+        else -> null
+    }
+
+    override fun serialize(input: Any?): Any? = when (input) {
+        is String -> UUID.fromString(input)
+        is UUID -> input
+        else -> null
+    }
+})


### PR DESCRIPTION
Added the 'scalars()' function to the SchemaParser.Builder to allow for adding custom instances of 'graphql.schema.GraphQLScalarType' for implementing GraphQL scalar types (see: https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/schema/GraphQLScalarType.java). Updated com.coxautodev.graphql.tools.EndToEndSpect.kt and test cases to account for the new functionality.